### PR TITLE
Fix tiny drum recipe

### DIFF
--- a/common/src/main/resources/data/immersive_melodies/recipes/tiny_drum.json
+++ b/common/src/main/resources/data/immersive_melodies/recipes/tiny_drum.json
@@ -18,7 +18,7 @@
     ],
     "W": [
       {
-        "tag": "minecraft:log"
+        "tag": "minecraft:logs"
       }
     ]
   },


### PR DESCRIPTION
Fixes the tiny drum recipe by making it use the correct `minecraft:logs` tag.

**Untested**, but I believe this is a simple enough fix, right?

Fixes #59 